### PR TITLE
fixed artifact id in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugin to provide commom breadcrumb model and template tag
 Add the jar to the projects dependencies:
 
 ```
-    "uk.gov.hmrc" %% "breadcrumb" % "0.0.0"
+    "uk.gov.hmrc" %% "play-breadcrumb" % "0.0.0"
 ```
 
 Add plugin to play.plugins:


### PR DESCRIPTION
Readme file has wrong artifact id for the library - 'breadcrumb' instead of 'play-breadcrumb'.
